### PR TITLE
Add unit tests for config / fetcher / repo

### DIFF
--- a/metadata/config/config_test.go
+++ b/metadata/config/config_test.go
@@ -1,0 +1,32 @@
+// Copyright 2023 VMware, Inc.
+//
+// This product is licensed to you under the BSD-2 license (the "License").
+// You may not use this product except in compliance with the BSD-2 License.
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to
+// the terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewUpdaterConfig(t *testing.T) {
+
+	remoteURL := "somepath"
+	rootBytes := []byte("somerootbytes")
+
+	updaterConfig, err := New(remoteURL, rootBytes)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, updaterConfig.RemoteMetadataURL, remoteURL)
+	assert.Equal(t, updaterConfig.LocalTrustedRoot, rootBytes)
+	assert.Equal(t, updaterConfig.RemoteTargetsURL, remoteURL+"/targets")
+}

--- a/metadata/config/config_test.go
+++ b/metadata/config/config_test.go
@@ -12,6 +12,8 @@
 package config
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,9 +26,65 @@ func TestNewUpdaterConfig(t *testing.T) {
 
 	updaterConfig, err := New(remoteURL, rootBytes)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+	assert.NotNil(t, updaterConfig)
+	assert.NotNil(t, updaterConfig.Fetcher)
 
+	assert.Equal(t, 32, updaterConfig.MaxDelegations)
+	assert.Equal(t, int64(32), updaterConfig.MaxRootRotations)
+	assert.Equal(t, int64(512000), updaterConfig.RootMaxLength)
+	assert.Equal(t, int64(16384), updaterConfig.TimestampMaxLength)
+	assert.Equal(t, int64(2000000), updaterConfig.SnapshotMaxLength)
+	assert.Equal(t, int64(5000000), updaterConfig.TargetsMaxLength)
+	assert.Equal(t, false, updaterConfig.DisableLocalCache)
+	assert.Equal(t, true, updaterConfig.PrefixTargetsWithHash)
 	assert.Equal(t, updaterConfig.RemoteMetadataURL, remoteURL)
 	assert.Equal(t, updaterConfig.LocalTrustedRoot, rootBytes)
 	assert.Equal(t, updaterConfig.RemoteTargetsURL, remoteURL+"/targets")
+	assert.Empty(t, updaterConfig.LocalMetadataDir)
+	assert.Empty(t, updaterConfig.LocalTargetsDir)
+}
+
+func TestEnsurePathsExist(t *testing.T) {
+
+	remoteURL := "somepath"
+	rootBytes := []byte("somerootbytes")
+
+	updaterConfig, err := New(remoteURL, rootBytes)
+	assert.NoError(t, err)
+	assert.NotNil(t, updaterConfig)
+
+	err = updaterConfig.EnsurePathsExist()
+	assert.Error(t, err, "mkdir : no such file or directory")
+
+	tmp := os.TempDir()
+	metadataPath := fmt.Sprintf("%s/metadata", tmp)
+	targetsPath := fmt.Sprintf("%s/targets", tmp)
+
+	assert.NoDirExists(t, metadataPath)
+	assert.NoDirExists(t, targetsPath)
+
+	updaterConfig.LocalMetadataDir = metadataPath
+	updaterConfig.LocalTargetsDir = targetsPath
+
+	updaterConfig.DisableLocalCache = true
+	err = updaterConfig.EnsurePathsExist()
+	assert.NoError(t, err)
+	assert.NoDirExists(t, metadataPath)
+	assert.NoDirExists(t, targetsPath)
+
+	updaterConfig.DisableLocalCache = false
+	err = updaterConfig.EnsurePathsExist()
+	assert.NoError(t, err)
+
+	assert.DirExists(t, metadataPath)
+	assert.DirExists(t, targetsPath)
+
+	err = os.RemoveAll(metadataPath)
+	assert.NoError(t, err)
+	assert.NoDirExists(t, metadataPath)
+
+	err = os.RemoveAll(targetsPath)
+	assert.NoError(t, err)
+	assert.NoDirExists(t, targetsPath)
 }

--- a/metadata/fetcher/fetcher_test.go
+++ b/metadata/fetcher/fetcher_test.go
@@ -1,0 +1,59 @@
+// Copyright 2023 VMware, Inc.
+//
+// This product is licensed to you under the BSD-2 license (the "License").
+// You may not use this product except in compliance with the BSD-2 License.
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to
+// the terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+package fetcher
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rdimitrov/go-tuf-metadata/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	exampleURL = "https://example.com/metadata/"
+	realUrl    = "https://jku.github.io/tuf-demo/metadata/1.root.json"
+)
+
+func TestDownloadFileWithExampleUrl(t *testing.T) {
+	fetcher := DefaultFetcher{httpUserAgent: ""}
+
+	data, err := fetcher.DownloadFile(exampleURL, 34)
+	if assert.NotNil(t, err) {
+		if assert.IsType(t, metadata.ErrDownloadHTTP{}, err) {
+			var checkErr metadata.ErrDownloadHTTP
+			if errors.As(err, &checkErr) {
+				assert.Equal(t, checkErr.StatusCode, 404)
+			}
+		}
+	}
+	assert.Empty(t, data)
+}
+
+func TestDownloadFileWithRealURL(t *testing.T) {
+	fetcher := DefaultFetcher{httpUserAgent: ""}
+
+	data, err := fetcher.DownloadFile(realUrl, 3000)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, data)
+
+	now := time.Now().UTC()
+	safeExpiry := now.Truncate(time.Second).AddDate(0, 0, 30)
+	mdRoot := metadata.Root(safeExpiry)
+	err = mdRoot.UnmarshalJSON(data)
+
+	assert.Nil(t, err)
+	assert.Equal(t, mdRoot.Signed.Type, metadata.ROOT)
+	assert.Equal(t, mdRoot.Signed.Version, int64(1))
+	assert.LessOrEqual(t, mdRoot.Signed.SpecVersion, metadata.SPECIFICATION_VERSION)
+}

--- a/metadata/fetcher/fetcher_test.go
+++ b/metadata/fetcher/fetcher_test.go
@@ -28,12 +28,15 @@ const (
 func TestDownloadFileWithExampleUrl(t *testing.T) {
 	fetcher := DefaultFetcher{httpUserAgent: ""}
 
+	fetcher.httpUserAgent = "someUserAgent"
+
 	data, err := fetcher.DownloadFile(exampleURL, 34)
 	if assert.NotNil(t, err) {
 		if assert.IsType(t, metadata.ErrDownloadHTTP{}, err) {
 			var checkErr metadata.ErrDownloadHTTP
 			if errors.As(err, &checkErr) {
-				assert.Equal(t, checkErr.StatusCode, 404)
+				assert.NotEqual(t, 200, checkErr.StatusCode)
+				assert.Equal(t, 404, checkErr.StatusCode)
 			}
 		}
 	}

--- a/metadata/repository/repository_test.go
+++ b/metadata/repository/repository_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 VMware, Inc.
+//
+// This product is licensed to you under the BSD-2 license (the "License").
+// You may not use this product except in compliance with the BSD-2 License.
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to
+// the terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rdimitrov/go-tuf-metadata/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRepository(t *testing.T) {
+	repo := New()
+
+	now := time.Now().UTC()
+	safeExpiry := now.Truncate(time.Second).AddDate(0, 0, 30)
+
+	root := metadata.Root(safeExpiry)
+	repo.SetRoot(root)
+	assert.Equal(t, "root", repo.Root().Signed.Type)
+	assert.Equal(t, int64(1), repo.Root().Signed.Version)
+	assert.Equal(t, metadata.SPECIFICATION_VERSION, repo.Root().Signed.SpecVersion)
+
+	targets := metadata.Targets(safeExpiry)
+	repo.SetTargets("targets", targets)
+	assert.Equal(t, "targets", repo.Targets("targets").Signed.Type)
+	assert.Equal(t, int64(1), repo.Targets("targets").Signed.Version)
+	assert.Equal(t, metadata.SPECIFICATION_VERSION, repo.Targets("targets").Signed.SpecVersion)
+
+	timestamp := metadata.Timestamp(safeExpiry)
+	repo.SetTimestamp(timestamp)
+	// repo.SetRoot(root)
+	assert.Equal(t, "timestamp", repo.Timestamp().Signed.Type)
+	assert.Equal(t, int64(1), repo.Timestamp().Signed.Version)
+	assert.Equal(t, metadata.SPECIFICATION_VERSION, repo.Timestamp().Signed.SpecVersion)
+
+	snapshot := metadata.Snapshot(safeExpiry)
+	repo.SetSnapshot(snapshot)
+	assert.Equal(t, "snapshot", repo.Snapshot().Signed.Type)
+	assert.Equal(t, int64(1), repo.Snapshot().Signed.Version)
+	assert.Equal(t, metadata.SPECIFICATION_VERSION, repo.Snapshot().Signed.SpecVersion)
+}


### PR DESCRIPTION
This change adds test coverage for the most basic types, 
covering UpdaterConfig, Fetcher and repositoryType