### PR TITLE
test: convert tests to table driven tests pattern for config pkg

### DIFF
--- a/metadata/config/config.go
+++ b/metadata/config/config.go
@@ -45,6 +45,7 @@ func New(remoteURL string, rootBytes []byte) (*UpdaterConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &UpdaterConfig{
 		// TUF configuration
 		MaxRootRotations:   32,
@@ -67,11 +68,12 @@ func (cfg *UpdaterConfig) EnsurePathsExist() error {
 	if cfg.DisableLocalCache {
 		return nil
 	}
+
 	for _, path := range []string{cfg.LocalMetadataDir, cfg.LocalTargetsDir} {
-		err := os.MkdirAll(path, os.ModePerm)
-		if err != nil {
+		if err := os.MkdirAll(path, os.ModePerm); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
I'll post this initial draft as to how I would refactor the tests. This pattern is called "table driven tests" and widely used in Google. It allows for easy addition of tests and creates new subtests using the `t.Run()` method for each member of an anonymous struct which is the testing table. This table defines a test name, description, expected outcome and allow modifying the control flow for individual tests easily. I started with the smallest package first as I wanted to get your opinion on this before I go ahead and sink time into the rest of the code. This pattern will come in handy especially for larger function with higher cyclomatic complexity. The added bonus is that we can also use `t.Log()` more often as it will only print on failed subtests or if run with `go test -v`.