### PR TITLE
ci: properly calculate coverage for metadata package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Run tests
-        run: go test -race -covermode atomic -coverprofile=coverage.out ./...
+        run: go test -race -covermode=atomic -coverpkg=./metadata/... -coverprofile=coverage.out ./...
 
       - name: Send coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
There was a missing flag in the CI to generate accurate coverage reports for the metadata package. This will now cover all of the metadata subfolder and exclude testutil and examples as those are not part of the core library