### PR TITLE
Updated the default ecdsa p256 key type to not include any parameters.

### DIFF
--- a/metadata/keys.go
+++ b/metadata/keys.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	KeyTypeEd25519               = "ed25519"
-	KeyTypeECDSA_SHA2_P256       = "ecdsa-sha2-nistp256"
-	KeyTypeECDSA_SHA2_P256_SSLIB = "ecdsa"
-	KeyTypeRSASSA_PSS_SHA256     = "rsa"
-	KeySchemeEd25519             = "ed25519"
-	KeySchemeECDSA_SHA2_P256     = "ecdsa-sha2-nistp256"
-	KeySchemeRSASSA_PSS_SHA256   = "rsassa-pss-sha256"
+	KeyTypeEd25519                = "ed25519"
+	KeyTypeECDSA_SHA2_P256_COMPAT = "ecdsa-sha2-nistp256"
+	KeyTypeECDSA_SHA2_P256        = "ecdsa"
+	KeyTypeRSASSA_PSS_SHA256      = "rsa"
+	KeySchemeEd25519              = "ed25519"
+	KeySchemeECDSA_SHA2_P256      = "ecdsa-sha2-nistp256"
+	KeySchemeRSASSA_PSS_SHA256    = "rsassa-pss-sha256"
 )
 
 // ToPublicKey generate crypto.PublicKey from metadata type Key
@@ -52,7 +52,7 @@ func (k *Key) ToPublicKey() (crypto.PublicKey, error) {
 			return nil, err
 		}
 		return rsaKey, nil
-	case KeyTypeECDSA_SHA2_P256, KeyTypeECDSA_SHA2_P256_SSLIB: // handle "ecdsa" too as python-tuf/sslib keys are using it for keytype instead of https://theupdateframework.github.io/specification/latest/index.html#keytype-ecdsa-sha2-nistp256
+	case KeyTypeECDSA_SHA2_P256, KeyTypeECDSA_SHA2_P256_COMPAT: // handle "ecdsa" too as python-tuf/sslib keys are using it for keytype instead of https://theupdateframework.github.io/specification/latest/index.html#keytype-ecdsa-sha2-nistp256
 		publicKey, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(k.Value.PublicKey))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Since TUF spec 1.0.32 the key type for ecdsa does not include the parameters, they are only part of the key-scheme.
This commit updates the default keytype to not include the parameters, but includes a compatibility key type to be able to accept metadata compliant with older versions of the spec.