### PR TITLE
Split actions to tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
       - "v*"
 name: CI
 jobs:
+  linting:
+    uses: ./.github/workflows/linting.yml
   tests:
     uses: ./.github/workflows/tests.yml
   examples:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,34 @@
+# Copyright 2022-2023 VMware, Inc.
+#
+# This product is licensed to you under the BSD-2 license (the "License").
+# You may not use this product except in compliance with the BSD-2 License.
+# This product may include a number of subcomponents with separate copyright
+# notices and license terms. Your use of these subcomponents is subject to
+# the terms and conditions of the subcomponent's license, as noted in the
+# LICENSE file.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+on:
+  workflow_call:
+name: Linting
+jobs:
+  linting:
+    name: Checks and linters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1
+        with:
+          version: v1.54
+          args: --timeout 5m --verbose
+          skip-cache: true
+      - name: govulncheck
+        uses: golang/govulncheck-action@7da72f730e37eeaad891fcff0a532d27ed737cd4
+        with:
+          go-version-file: 'go.mod'
+          go-package: ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: arnested/go-version-action@b556f8d91b644164318c709d28b9083eaf0c064d
         id: versions
-
   run:
     name: Run
     strategy:
@@ -47,27 +46,3 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           flags: Go-${{ matrix.go-version }}
-
-  checks:
-    name: Checks and linters
-    strategy:
-      matrix:
-        go-version: ${{ fromJSON(needs.get-go-versions.outputs.matrix) }}
-    runs-on: ubuntu-latest
-    needs: get-go-versions
-    steps:
-      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
-        with:
-          go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1
-        with:
-          version: v1.51 # has to be pinned and thus manually updated due to https://github.com/golangci/golangci-lint-action/blob/6a290f7d5d488e1e423b0b37fe802c822ca2c08c/README.md?plain=1#L108
-          args: --timeout 5m --verbose
-      - name: govulncheck
-        uses: golang/govulncheck-action@7da72f730e37eeaad891fcff0a532d27ed737cd4
-        with:
-          go-version-input: ${{ matrix.go-version }}
-          go-package: ./...
-


### PR DESCRIPTION
The following PR:
* splits the workflows to one for linting and one for tests
* updates some of the action's settings to address issues like https://github.com/rdimitrov/go-tuf-metadata/actions/runs/7129104975/job/19412986382#step:5:88